### PR TITLE
Require railtie if rails is defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,5 +35,4 @@ metadata and timestamp. For example
 
 ## Rails integration
 
-If you include `logger-metadata` in a Rails application Gemfile and require
-`logger/metadata/railtie`, metadata logging will be automatically set up.
+Rails application is automatically setup by requiring `logger/metadata/railtie` if `Rails` is defined.

--- a/lib/logger/metadata.rb
+++ b/lib/logger/metadata.rb
@@ -1,6 +1,7 @@
 require 'logger'
 require 'logger/metadata/version'
 require 'logger/metadata/formatter'
+require 'logger/metadata/railtie' if defined?(Rails)
 
 class Logger
   # Metadata mixin for Ruby Logger


### PR DESCRIPTION
This line seems not to be present in the repository, even though gem release 0.1.1 has it. Most likely it was forgotten to be commited when the release was done.

    $ gem unpack logger-metadata
    Unpacked gem: '/tmp/logger-metadata-0.1.1'

    $ head lib/logger/metadata.rb
    require 'logger'
    require 'logger/metadata/version'
    require 'logger/metadata/formatter'
    require 'logger/metadata/railtie' if defined?(Rails)

    class Logger
      # Metadata mixin for Ruby Logger