### PR TITLE
GitHub Actions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -23,3 +23,24 @@ jobs:
           gem install bundler
           bundle install --jobs 4 --retry 3
           bundle exec rake
+  publish:
+    runs-on: ubuntu-latest
+    needs: [publish]
+    steps:
+      - uses: actions/checkout@master
+        if: startsWith(github.ref, 'refs/tags/v')
+      - name: Set up Ruby
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.6.x
+      - name: Publish to RubyGems
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          mkdir -p $HOME/.gem
+          printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+          chmod 0600 $HOME/.gem/credentials
+          gem build *.gemspec
+          gem push *.gem
+        env:
+          GEM_HOST_API_KEY: ${{secrets.GEM_HOST_API_KEY}}

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -25,7 +25,7 @@ jobs:
           bundle exec rake
   publish:
     runs-on: ubuntu-latest
-    needs: [publish]
+    needs: [build]
     steps:
       - uses: actions/checkout@master
         if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -44,3 +44,7 @@ jobs:
           gem push *.gem
         env:
           GEM_HOST_API_KEY: ${{secrets.GEM_HOST_API_KEY}}
+      - uses: smartlyio/github-release-notes-action@v1.0.0
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,25 @@
+name: Ruby Gem
+
+on: [push]
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        ruby: [2.3.x, 2.4.x, 2.5.x, 2.6.x]
+
+    steps:
+      - uses: actions/checkout@master
+      - name: Set up Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+
+      - name: Build and test with Rake
+        run: |
+          gem install bundler
+          bundle install --jobs 4 --retry 3
+          bundle exec rake

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,7 +12,7 @@ jobs:
         ruby: [2.3.x, 2.4.x, 2.5.x, 2.6.x]
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v1
       - name: Set up Ruby
         uses: actions/setup-ruby@v1
         with:
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v1
         if: startsWith(github.ref, 'refs/tags/v')
       - name: Set up Ruby
         if: startsWith(github.ref, 'refs/tags/v')

--- a/.grenrc
+++ b/.grenrc
@@ -1,0 +1,9 @@
+{
+    "dataSource": "prs",
+    "prefix": "",
+    "onlyMilestones": false,
+    "groupBy": false,
+    "template": {
+      "issue": "- [{{text}}]({{url}}) {{name}}"
+    }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-sudo: false
-language: ruby
-cache: bundler
-rvm:
-  - 2.2.6
-  - 2.3.3
-  - 2.4.0
-  - jruby-9.1.7.0
-before_install: gem install bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ rvm:
   - 2.3.3
   - 2.4.0
   - jruby-9.1.7.0
-before_install: gem install bundler -v 1.13.6
+before_install: gem install bundler

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+## Release process
+
+logger-metadata uses [Semantic Versioning](https://semver.org).
+
+Use `bundle exec rake release:major`, `bundle exec rake release:minor`, or `bundle exec release bump:patch` to change the version (in master branch). This will make a commit to bump version, and push it back to GitHub. Github actions then publishes the gem to rubygems.org.

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,20 @@
-require "bundler/gem_tasks"
+require "bump/tasks"
 require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new(:spec)
 
 task :default => :spec
+
+Bump.tag_by_default = true
+
+namespace :release do
+  task :git_push do
+    `git push origin`
+    `git push origin v#{::Bump::Bump.current}`
+  end
+
+  %w[major minor patch].each do |part|
+    desc "Bump #{part} of gem version and release"
+    task part => ["bump:#{part}", "release:git_push"]
+  end
+end

--- a/logger-metadata.gemspec
+++ b/logger-metadata.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "actionpack"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "railties"
-  spec.add_development_dependency "bundler", "~> 1.13"
-  spec.add_development_dependency "rake", "~> 11.0"
+  spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.5"
 end

--- a/logger-metadata.gemspec
+++ b/logger-metadata.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "actionpack"
   spec.add_development_dependency "bundler", "~> 2.0"
+  spec.add_development_dependency "bump", "~> 0.8.0"
   spec.add_development_dependency "railties"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.5"


### PR DESCRIPTION
Use Github Actions for CI and to publish tags automatically to Rubygems.org.

Bumping version number can be done on command line with `rake release:major`, `rake release:minor` and `rake release:patch`