### PR TITLE
Revert "Create renovate.json"

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,0 @@
-{
-  "extends": [
-    "github>smartlyio/renovate-config:shared/team-base"
-  ]
-}


### PR DESCRIPTION
Reverts smartlyio/logger-metadata#10 because this is a public repo and so can't rely on the private renovate config